### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collection of optimized WebAssembly transcoders for [Basis Universal](https://github.com/BinomialLLC/basis_universal/) compressed GPU texture formats.
 
-These transcoders accept only low-level compressed payloads. Containers such as `.basis` or [KTX](https://github.khronos.org/KTX-Specification/) should be decoded by other means.
+These transcoders accept only low-level compressed payloads. Containers such as `.basis` or `.ktx2` ([KTX](https://github.khronos.org/KTX-Specification/)) should first be parsed by other means, then transcoded to the target format with this library.
 
 ## Implementation Status
 


### PR DESCRIPTION
Minor clarification to the introduction, for users who may misinterpret this as saying the transcoders are not applicable to .basis or .ktx2 textures.